### PR TITLE
ft: link more examples

### DIFF
--- a/docs/ambiorix/02-hello-world.md
+++ b/docs/ambiorix/02-hello-world.md
@@ -23,10 +23,11 @@ app$start()
 In your browser, visit `/` to see the homepage, and visit
 `/about` to see the about page.
 
-## Introduction
+# Introduction
 
 There is also a short video introducing the framework.
 
 <div class="video-container">
 <iframe src="https://www.youtube.com/embed/owpbIQ-j6Kk" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 </div>
+ 

--- a/docs/ambiorix/11-websocket.md
+++ b/docs/ambiorix/11-websocket.md
@@ -26,7 +26,7 @@ One can also instantiate the class to add handlers with `receive` method then ru
 
 ```js
 var wss = new Ambiorix();
-wss.receive("hello", \(msg){
+wss.receive("hello", (msg) => {
   alert(msg);
 });
 wss.start();
@@ -44,7 +44,7 @@ And `receive`, a method to add listeners, very much like the `receive` method in
 
 ```js
 var wss = new Ambiorix();
-wss.receive("hello", \(msg){
+wss.receive("hello", (msg) => {
   alert(msg);
 });
 ```

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -1,3 +1,10 @@
+# Websites  
+
+Examples of sites built using ambiorix:
+
+- [URL shortener](https://rrr.is/)
+- [Personal website](https://mwavu.com/)
+
 # Examples
 
 Useful examples to learn more about ambiorix.
@@ -10,8 +17,8 @@ Useful examples to learn more about ambiorix.
 
 # More examples
 
-Here are more examples provided by [Kennedy Mwavu](https://github.com/kennedymwavu):
-
+Explanations for these examples can be found here: [ambiorix-examples](https://kennedymwavu.github.io/ambiorix-examples/)
+ 
 1. [Hello, World!](https://github.com/kennedymwavu/ambiorix-examples/tree/main/01_hello_world)
 1. [Serving static files](https://github.com/kennedymwavu/ambiorix-examples/tree/main/02_static_files)
 1. [Basic routing](https://github.com/kennedymwavu/ambiorix-examples/tree/main/03_basic_routing)
@@ -21,12 +28,9 @@ Here are more examples provided by [Kennedy Mwavu](https://github.com/kennedymwa
 1. [Dynamic rendering](https://github.com/kennedymwavu/ambiorix-examples/tree/main/07_dynamic_rendering)
 1. [Datatables](https://github.com/kennedymwavu/ambiorix-examples/tree/main/08_datatables)
 1. [Build a CRUD backend: **Goals**](https://github.com/kennedymwavu/ambiorix-examples/tree/main/09_goals)
-
-   - Ambiorix + MongoDB
-
-   - Working with middleware:
-
-       - Auth middleware
-
-       - Error handling middleware
 1. [Live reloading](https://github.com/kennedymwavu/ambiorix-examples/tree/main/10_live_reloading)
+1. [CSV & XLSX file upload](https://github.com/kennedymwavu/ambiorix-examples/tree/main/11_csv_xlsx_upload)
+1. [Shiny frontend for the CRUD backend](https://github.com/kennedymwavu/ambiorix-examples/tree/main/12_shiny_frontend_for_09_goals)
+1. [Parsing raw JSON](https://github.com/kennedymwavu/ambiorix-examples/tree/main/13_parse_raw_json)
+1. [Allow CORS](https://github.com/kennedymwavu/ambiorix-examples/tree/main/14_cors)
+

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -109,7 +109,7 @@ const config = {
             ],
           },
         ],
-        copyright: `Copyright © ${new Date().getFullYear()} My Project, Inc. Built with Docusaurus.`,
+        copyright: `Copyright © ${new Date().getFullYear()} Ambiorix`,
       },
       prism: {
         theme: lightCodeTheme,


### PR DESCRIPTION
- update footer from the default "My project" to "Ambiorix"
- link real-world sites built using ambiorix
- link to the examples site
- fix error in websockets examples where R's `\() {}` was used instead of JS's `() => {}`

closes #6 