### PR TITLE
ft: add shiny server deployment option

### DIFF
--- a/docs/ambiorix/19-deploy.md
+++ b/docs/ambiorix/19-deploy.md
@@ -90,6 +90,128 @@ One of the easiest way to deploy an ambiorix app is by using [docker](https://ww
     This stops and removes the containers but keeps the Docker images intact, so you can start them again
     later with `docker compose up`.
 
+## Shiny Server
+
+Surprise surprise! Yes, you can actually deploy Ambiorix apps & APIs using [Shiny Server](https://docs.posit.co/shiny-server/#getting-started).
+
+This is such good news because you can put your Ambiorix & Shiny apps in one directory and
+have Shiny Server serve all of them!
+
+**Two things to keep in mind:**
+
+- All your Ambiorix entrypoints will have to be named `app.R`, you can't just
+name the files anyhow (eg. `index.R`, `server.R`, etc) because Shiny Server will search for `app.R`.
+- When building frontend applications using Ambiorix, you'd normally set the `href` attributes of anchor tags to someting like `/about` or `/contact` to link to the different endpoints within the same app. However, when the app is hosted on Shiny Server at a URL like `http://localhost:3838/app-name`, using `/about` as the link will direct the browser to `http://localhost:3838/about` (outside your app), which isn't what you intend. To fix this, you need to prepend the app name to the `href` values, like `href = "/app-name/about"`. This ensures that the links point the browser to the correct routes within your app.
+
+**Example deployment:**
+
+Before Shiny Server starts an R process, it sets the `SHINY_PORT` environment variable, which
+tells the app which port to run on. In your Ambiorix app, you can retrieve this port using
+`Sys.getenv("SHINY_PORT")`.
+
+1. Build your app. Say I have this `app.R` at `/home/mwavu/projects/random`:
+
+    ```r
+    library(ambiorix)
+    library(htmltools)
+
+    home_get <- \(req, res) {
+      html <- tags$h3("Yes, Ambiorix IN Shiny Server!")
+      res$set_status(200L)$send(html)
+    }
+
+    home_post <- \(req, res) {
+      response <- list(
+        code = 200L,
+        msg = "An API too!"
+      )
+      res$set_status(200L)$json(response)
+    }
+
+    # get port to run app on from Shiny Server
+    port <- Sys.getenv("SHINY_PORT")
+
+    Ambiorix$
+      new(port = port)$
+      get("/", home_get)$
+      post("/", home_post)$
+      start()
+    ```
+
+1. Configure Shiny Server to serve apps from the `/home/mwavu/projects` directory. Shiny Server configuration file is typically located at `/etc/shiny-server/shiny-server.conf`.
+
+    ```nginx
+    run_as mwavu; # user under which Shiny Server runs
+
+    server {
+      listen 3838;
+
+      # define a location at the base URL
+      location / {
+
+        # host the directory of ambiorix/shiny apps stored in this dir:
+        site_dir /home/mwavu/projects;
+
+        # log dir:
+        log_dir /var/log/shiny-server;
+
+        # ...other configs...
+      }
+    }
+    ```
+
+1. Restart Shiny Server
+
+    ```bash
+    systemctl restart shiny-server.service
+    ```
+
+1. Now visit [localhost:3838/random](http://localhost:3838/random). Voila!
+
+**An Important Consideration:**
+
+While the open-source version of Shiny Server will work well for most users, some advanced
+functionality (such as managing the number of R processes, load balancing, etc.) will require Shiny Server Professional. In the long run, you'd benefit from learning how to implement these features independently, especially for more control & flexibility.
+
+## Shinyapps.io
+
+You can use that same solution for deploying using Shiny Server to host your Ambiorix apps & APIs on [shinyapps.io](https://shinyapps.io/).
+
+Good thing is now you won't have to deal with any configurations. All you need to remember is to get the port to run the app on and the point I made on anchor tags (if building the frontend).
+
+1. Using the same example app:
+
+    ```r
+    library(ambiorix)
+    library(htmltools)
+
+    home_get <- \(req, res) {
+      html <- tags$h3("Ambiorix IN shinyapps.io!")
+      res$set_status(200L)$send(html)
+    }
+
+    home_post <- \(req, res) {
+      response <- list(
+        code = 200L,
+        msg = "An API too!"
+      )
+      res$set_status(200L)$json(response)
+    }
+
+    # get port to run app on from Shiny Server
+    port <- Sys.getenv("SHINY_PORT")
+
+    Ambiorix$
+      new(port = port)$
+      get("/", home_get)$
+      post("/", home_post)$
+      start()
+    ```
+
+1. Follow the same steps as for a shiny app: [how to deploy to shinyapps.io](https://shiny.posit.co/r/articles/share/shinyapps/).
+
+See [example live app](https://mwavu.shinyapps.io/hello/) running on shinyapps.io
+
 ## Systemd Service
 
 The application can be deployed as a service on any Linux server.

--- a/docs/ambiorix/20-load-balancing.md
+++ b/docs/ambiorix/20-load-balancing.md
@@ -1,0 +1,7 @@
+# Load Balancing
+
+## Belgic
+
+There is now a load balancer for ambiorix applications so
+one can serve concurrent users with ease.
+The load balancer is documented [here](/docs/belgic).


### PR DESCRIPTION
- improve current docs on docker & systemd
- add shiny server & shinyapps.io as deployment options
- separate load balancing from deployment section, reason being we intend to add more load balancing options in the future